### PR TITLE
Prevent program to break if hooks is empty

### DIFF
--- a/files/index.js
+++ b/files/index.js
@@ -710,7 +710,7 @@ function defaultAcceptWebsocket(request, upgrade) {
   return upgrade(request);
 }
 
-if(server.options.hooks.handleWebsocket) {
+if(server.options?.hooks?.handleWebsocket) {
   let origFetch = serveOptions.fetch;
   serveOptions.websocket = server.options.hooks.handleWebsocket;
   serveOptions.fetch = (req, srv) => {


### PR DESCRIPTION
server.options.hooks.handleWebsocket might be null some time and cause program to break `TypeError: undefined is not an object (evaluating 'server.options.hooks')`

<img width="441" alt="image" src="https://user-images.githubusercontent.com/19445033/223444428-2a3aaeff-c0e1-439f-a637-a3c79f3ddf51.png">
